### PR TITLE
feat: Add disabled message when MAX_PARCELS is 0

### DIFF
--- a/src/main/java/net/borisshoes/fabricmail/FabricMail.java
+++ b/src/main/java/net/borisshoes/fabricmail/FabricMail.java
@@ -313,9 +313,15 @@ public class FabricMail implements ModInitializer {
                   outbound++;
                }
             }
-            if(outbound >= maxOutbound && !Commands.LEVEL_ADMINS.check(context.getSource().permissions())){
-               source.sendFailure(Component.translatable("text.fabricmail.max_outbound_reached"));
-               return -1;
+
+            if (!Commands.LEVEL_ADMINS.check(context.getSource().permissions())) {
+               if (maxOutbound == 0) {
+                  source.sendFailure(Component.translatable("text.fabricmail.parcel_disabled"));
+                  return -1;
+               }else if(outbound >= maxOutbound){
+                  source.sendFailure(Component.translatable("text.fabricmail.max_outbound_reached"));
+                  return -1;
+               }
             }
          }
          

--- a/src/main/resources/data/fabricmail/lang/en_us.json
+++ b/src/main/resources/data/fabricmail/lang/en_us.json
@@ -52,6 +52,7 @@
   "text.fabricmail.only_players_receive": "Only players can receive mail",
   "text.fabricmail.only_players_send": "Only players can send mail",
   "text.fabricmail.parcel_added_inventory": "This Mail contained a Parcel. It has been added to your Inventory.",
+  "text.fabricmail.parcel_disabled": "Parcels are disabled on this server",
   "text.fabricmail.received_mail": "You Just Received Mail!",
   "text.fabricmail.recipient_not_exist": "Recipient Does Not Exist",
   "text.fabricmail.revoked_mail_to": "Revoked Mail to %s.",


### PR DESCRIPTION
Adds a small check that returns a 'disabled on this server' message instead of the 'max reached' message when MAX_PARCELS is equal to zero. A specific toggle for this would be better but this also works.

I have been unable to test because I could not get the environment to work.